### PR TITLE
Avoid Generating unused `use statements`

### DIFF
--- a/src/Generators/DtoGenerator.php
+++ b/src/Generators/DtoGenerator.php
@@ -45,7 +45,7 @@ class DtoGenerator
             'constructor_params' => $constructorParams,
             'from_request_method' => $fromRequestMethod,
             'readonly' => $this->isReadonly(),
-            'generate_from_request' => $this->shouldGenerateFromRequest(),
+            'generate_from_request' => $this->shouldGenerateFromRequest() && $fromRequestMethod !== '',
             'use_imports' => true,
         ]);
     }
@@ -242,7 +242,7 @@ class DtoGenerator
                         "        if ({$varName} !== null && !({$varName} instanceof \\Carbon\\Carbon)) {\n" .
                         "            {$varName} = \\Carbon\\Carbon::parse({$varName});\n" .
                         "        }";
-            } 
+            }
 
             return "        {$varName} = {$validatedCall};\n" .
                     "        if (!({$varName} instanceof \\Carbon\\Carbon)) {\n" .


### PR DESCRIPTION
We don't need to generate the `use statement` of Request when `fromRequest` function where it's used is not generated.